### PR TITLE
Restore fail gracefully

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "eslint-plugin-promise": "2.0.0",
     "eslint-plugin-standard": "2.0.0",
     "mocha": "^2.5.3",
-    "mock-fs": "^3.11.0"
+    "mock-fs": "^3.11.0",
+    "sinon": "^1.17.6",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/src/consulBackupRestore.js
+++ b/src/consulBackupRestore.js
@@ -58,15 +58,17 @@ ConsulBackupRestore.prototype.restore = function (options, callback) {
   } else {
     fs.readFile(options.filePath, 'utf8', (err, data) => {
       if (err) callback(err)
-      consulUtil.restoreKeyValues(this.consulInstance, data, options.override, (err, result) => {
-        if (err) {
-          callback(err)
-        }
-        if (result) {
-          var blanksRemoved = result.filter(function (e) { return e })
-          callback(null, blanksRemoved)
-        }
-      })
+      if (data) {
+        consulUtil.restoreKeyValues(this.consulInstance, data, options.override, (err, result) => {
+          if (err) {
+            callback(err)
+          }
+          if (result) {
+            var blanksRemoved = result.filter(function (e) { return e })
+            callback(null, blanksRemoved)
+          }
+        })
+      }
     })
   }
 }

--- a/src/consulBackupRestore.js
+++ b/src/consulBackupRestore.js
@@ -45,15 +45,17 @@ ConsulBackupRestore.prototype.restore = function (options, callback) {
     const s3 = new AWS.S3({params: {Bucket: options.s3BucketName}})
     s3.getObject({Bucket: options.s3BucketName, Key: options.filePath}, (err, data) => {
       if (err) callback(err)
-      consulUtil.restoreKeyValues(this.consulInstance, data.Body, options.override, (err, result) => {
-        if (err) {
-          callback(err)
-        }
-        if (result) {
-          var blanksRemoved = result.filter(function (e) { return e })
-          callback(null, blanksRemoved)
-        }
-      })
+      else {
+        consulUtil.restoreKeyValues(this.consulInstance, data.Body, options.override, (err, result) => {
+          if (err) {
+            callback(err)
+          }
+          if (result) {
+            var blanksRemoved = result.filter(function (e) { return e })
+            callback(null, blanksRemoved)
+          }
+        })
+      }
     })
   } else {
     fs.readFile(options.filePath, 'utf8', (err, data) => {

--- a/test/consulBackupRestore.js
+++ b/test/consulBackupRestore.js
@@ -1,4 +1,4 @@
-var assert = require('chai').assert
+var chai = require('chai')
 var ConsulBackupRestore = require('../src')
 var cbr = new ConsulBackupRestore({host: 'localhost', port: 8500})
 var describe = require('mocha').describe
@@ -7,8 +7,14 @@ var it = require('mocha').it
 var fs = require('fs')
 var mock = require('mock-fs')
 var axios = require('axios')
-
+var sinon = require('sinon')
+var sinonChai = require('sinon-chai')
+var assert = chai.assert
 var consulTestUtil = require('./consulTestUtil')
+var consulUtil = require('../src/consulUtil')
+
+chai.should()
+chai.use(sinonChai)
 
 var changedValue = 'changedValue'
 var newKey1 = 'newKey1'
@@ -66,6 +72,17 @@ describe('consul-back-restore', function () {
             done()
           }
         })
+      })
+    })
+
+    it('should not attempt to restore when file not found', function (done) {
+      sinon.spy(consulUtil, 'restoreKeyValues')
+      var cbr = new ConsulBackupRestore({host: 'localhost', port: 8500})
+      cbr.restore({filePath: '/test/keynotfound'}, function (err, result) {
+        assert.equal(err.code, 'ENOENT')
+        assert.isUndefined(result)
+        consulUtil.restoreKeyValues.should.have.not.been.called
+        done()
       })
     })
   })


### PR DESCRIPTION
If there is an error retrieving data from a local or s3 file, do not call consulUtil.restoreKeyValues().